### PR TITLE
通知機能をカスタマイズ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'slack-notifier'
+gem 'slack-api'
 gem 'awesome_print'
 gem 'pry'
 gem 'net-ssh'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,17 @@ GEM
     awesome_print (1.2.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
+    eventmachine (1.0.9.1)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    faye-websocket (0.9.2)
+      eventmachine (>= 0.12.0)
+      websocket-driver (>= 0.5.1)
     method_source (0.8.2)
+    multi_json (1.11.2)
+    multipart-post (2.0.0)
     net-ssh (2.8.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -18,8 +28,15 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    slack-notifier (0.5.0)
+    slack-api (1.2.1)
+      faraday (>= 0.7, < 0.10)
+      faraday_middleware (~> 0.8)
+      faye-websocket (~> 0.9.2)
+      multi_json (~> 1.0, >= 1.0.3)
     slop (3.5.0)
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
 
 PLATFORMS
   ruby
@@ -29,4 +46,7 @@ DEPENDENCIES
   net-ssh
   pry
   rspec
-  slack-notifier
+  slack-api
+
+BUNDLED WITH
+   1.11.2

--- a/lib/gerrit_notifier.rb
+++ b/lib/gerrit_notifier.rb
@@ -1,3 +1,4 @@
+require 'slack'
 class GerritNotifier
   extend Alias
 
@@ -51,13 +52,12 @@ class GerritNotifier
 
           if @@buffer.size > 0 && !ENV['DEVELOPMENT']
             @@buffer.each do |channel, messages|
-              notifier = Slack::Notifier.new slack_config['team'], slack_config['token']
-              notifier.ping(messages.join("\n\n"),
-                channel: channel,
-                username: 'gerrit',
-                icon_emoji: ':dragon_face:',
-                link_names: 1
-              )
+              message = messages.join("\n\n")
+
+              Slack.configure do |config|
+                config.token = slack_config['token']
+              end
+              Slack.chat_postMessage text:message, username:slack_config['username'], icon_emoji:slack_config['icon_emoji'], channel: channel
             end
           end
 

--- a/lib/gerrit_notifier.rb
+++ b/lib/gerrit_notifier.rb
@@ -50,7 +50,7 @@ class GerritNotifier
             ap @@buffer
           end
 
-          if @@buffer.size > 0 && !ENV['DEVELOPMENT']
+          if @@buffer.size > 0 #&& !ENV['DEVELOPMENT']
             @@buffer.each do |channel, messages|
               message = messages.join("\n\n")
 

--- a/lib/gerrit_notifier.rb
+++ b/lib/gerrit_notifier.rb
@@ -50,14 +50,16 @@ class GerritNotifier
 
           if @@buffer.size > 0 #&& !ENV['DEVELOPMENT']
             @@buffer.each do |channel, messages|
-              message = messages.join("\n\n")
+              messages.each do |message|
 
-              next if ignore? message
+                next if ignore? message
 
-              Slack.configure do |config|
-                config.token = slack_config['token']
+                Slack.configure do |config|
+                  config.token = slack_config['token']
+                end
+                Slack.chat_postMessage text:message, username:slack_config['username'], icon_emoji:slack_config['icon_emoji'], channel: channel
+                sleep 1
               end
-              Slack.chat_postMessage text:message, username:slack_config['username'], icon_emoji:slack_config['icon_emoji'], channel: channel
             end
           end
 

--- a/lib/update.rb
+++ b/lib/update.rb
@@ -16,6 +16,10 @@ class Update
     json['change']['project'] if json['change']
   end
 
+  def patchset_created?
+    type == 'patchset-created'
+  end
+
   def comment_added?
     type == 'comment-added'
   end
@@ -51,7 +55,11 @@ class Update
       break if line =~ /Reviewer (DID NOT )?check/
       frd_lines << line
     }
-    frd_lines.join("\n\n")
+    frd_lines.join("")
+  end
+
+  def patchset
+    "Patch Set #{json['patchSet']['number']}"
   end
 
   def commit


### PR DESCRIPTION
slack-api に対応していないのと通知のメッセージが見づらいのでいろいろとカスタマイズします。
- [○] slack-api に対応
- [○] コミットメッセージに任意の文字列が含まれていたら通知しない機能追加
- [○] アイコンは yml で設定可能にする
- [○] QA と CodeReview を分ける必要はないので CodeReview にまとめる
- [] CodeReview とコメントの通知を分ける必要はないのでまとめる?
- [○] 通知に PatchSet 番号を必ず表示する
- [] 通知に branch を必ず表示する?
- [○] +1 や -1 から 0 に戻したときも通知する
- [○] 通知が重なったときも１つにまとめないで順番に通知する
